### PR TITLE
Add a 10 second delay between socket connect and RMT command.

### DIFF
--- a/lib/RiscoChannels.js
+++ b/lib/RiscoChannels.js
@@ -602,6 +602,13 @@ class Risco_DirectTCP_Socket extends Risco_Base_Socket {
             await new Promise(r => setTimeout(r, 100));
         }
 
+        // As we don't know what age of panel we're connecting to,
+        // we need to wait for 10 seconds before sending the RMT
+        // command, or the panel will fail to respond, and get
+        // stuck in a timeout/disconnect loop.
+        // CS waits for 10 seconds here regardless of panel.
+        await new Promise(r => setTimeout(r, 10000));
+
         let PossibleKey = 9999;
         let ConnectPanel;
 


### PR DESCRIPTION
On older panels, this will ensure connection is successful.

The configuration software waits 10 seconds regardless of the panel type - it seems that this is needed for the older IPC cards on LightSYS systems, at least.